### PR TITLE
Mark example links with ticks to avoid markdown link checking. (#366)

### DIFF
--- a/samples/apps/copilot-chat-app/README.md
+++ b/samples/apps/copilot-chat-app/README.md
@@ -34,7 +34,7 @@ and these components are functional:
    [Follow the steps to register an app here.](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app)
 
     1. Select Single-page application (SPA) as platform type, and the redirect
-       URI will be `http://localhost:3000`
+       URI will be `http://localhost:3000`.
     2. Select `Accounts in any organizational directory and personal Microsoft Accounts`
        as supported account types for this sample.
     3. Make a note of this Application (client) ID from the Azure Portal, we will
@@ -56,7 +56,7 @@ and these components are functional:
               your instance.
             * `“DeploymentOrModelID”: “text-davinci-003”,` or whichever option is
               appropriate for your instance.  
-            * `“Endpoint”:` “Your Azure Endpoint address, i.e. http://contoso.openai.azure.com”.
+            * `“Endpoint”:` “Your Azure Endpoint address, i.e. `http://contoso.openai.azure.com`”.
               If you are using OpenAI, leave this blank.
             * You will insert your Azure endpoint key during build of the backend
               API Server
@@ -94,7 +94,7 @@ and these components are functional:
     2. Copy `.env.example` into a new file with the name “`.env`” and make the
        following configuration changes to match your instance:
     3. Use the Application (client) ID from the Azure Portal steps above and
-       paste the GUID into the .env file next to `REACT_APP_CHAT_CLIENT_ID= `
+       paste the GUID into the `.env` file next to `REACT_APP_CHAT_CLIENT_ID= `
     4. Execute the command `yarn install`
     5. Execute the command `yarn start`
 
@@ -118,7 +118,7 @@ permission to connect.
 To resolve this, try the following:
 
 1. Confirm the backend service is running by opening a web browser, and navigating
-   to `https://localhost:40443/probe`
+   to `https://localhost:40443/probe`.
 2. You should see a confirmation message: `Semantic Kernel service is up and running`
 3. If your browser asks you to acknowledge the risks of visiting an insecure
    website, you must acknowledge the message before the front end will be

--- a/samples/apps/copilot-chat-app/WebApp/README.md
+++ b/samples/apps/copilot-chat-app/WebApp/README.md
@@ -17,7 +17,7 @@ The Copilot Chat sameple showcases how to build an enriched intelligent app, wit
 
 1. Azure Open AI Service Key and working End point. (https://learn.microsoft.com/en-us/azure/cognitive-services/openai/quickstart?tabs=command-line&pivots=programming-language-studio)
 2. A registered App in Azure Portal (https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app)
-   - Select Single-page application (SPA) as platform type, and the Redirect URI will be http://localhost:3000
+   - Select Single-page application (SPA) as platform type, and the Redirect URI will be `http://localhost:3000`
    - Select **`Accounts in any organizational directory (Any Azure AD directory - Multitenant) and personal Microsoft accounts (e.g. Skype, Xbox)`** as the supported account type for this sample.
    - Note the **`Application (client) ID`** from your app registration.
 3. Yarn - used for installing the app's dependencies (https://yarnpkg.com/getting-started/install)
@@ -25,13 +25,14 @@ The Copilot Chat sameple showcases how to build an enriched intelligent app, wit
 ## Running the sample
 
 1. Ensure the SKWebApi is running at `https://localhost:40443/`. See [SKWebApi README](../SKWebApi/README.md) for instructions.
-2. Create an **[.env](.env)** file to this folder root with the following variables and fill in with your information, where
+2. Create an `.env` file to this folder root with the following variables and fill in with your information, where
    `REACT_APP_CHAT_CLIENT_ID=` is the GUID copied from the **Application (client) ID** from your app registration in the Azure Portal and
    `REACT_APP_BACKEND_URI=` is the URI where your backend is running.
 
+   ```
    REACT_APP_BACKEND_URI=https://localhost:40443/
-
    REACT_APP_CHAT_CLIENT_ID=
+   ```
 
 3. **Run** the following command `yarn install` (if you have never run the app before) and/or `yarn start` from the command line.
 4. A browser will automatically open, otherwise you can navigate to `http://localhost:3000/` to use the ChatBot.


### PR DESCRIPTION
### Motivation and Context
The markdown link checker is failing with some links in the CopilotChat READMEs.

### Description
Make sure all example links, such as contoso and env files", and annotated with ticks to avoid the link checker trying to validate them.

### Motivation and Context
<!--

Please help reviewers and future users, providing the following information:

1. Why is this change required?
2. What problem does it solve?
3. What scenario does it contribute to?
4. If it fixes an open issue, please link to the issue here.
-->


### Description
<!--

Describe your changes, the overall approach, the underlying design.

These notes will help understanding how your code works. Thanks!
-->


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

<!-- Thank you for your contribution to the semantic-kernel repo! -->
